### PR TITLE
extauth-hook-ad: Fix false positive typing warnings, cleanup pylint

### DIFF
--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -55,6 +55,7 @@ jobs:
           --junitxml=.git/pytest${{matrix.python-version}}.xml
           --cov-report term-missing
           --cov-report xml:.git/coverage${{matrix.python-version}}.xml
+          --cov-fail-under 0
         env:
           PYTHONDEVMODE: yes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,8 +263,6 @@ expected_to_fail = [
     # Need 2to3 -w <file> and maybe a few other minor updates:
     "scripts/backup-sr-metadata.py",
     "scripts/restore-sr-metadata.py",
-    # Other fixes needed:
-    "scripts/plugins/extauth-hook-AD.py",
 ]
 
 # -----------------------------------------------------------------------------

--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -29,7 +29,8 @@ import XenAPI
 # - /etc/pam.d/hcp_users
 # - /etc/ssh/ssh_config
 
-# pylint: disable=super-with-arguments
+# pylint: disable=too-few-public-methods
+# pytype: disable=ignored-abstractmethod
 
 
 HCP_USERS = "/etc/security/hcp_ad_users.conf"
@@ -81,10 +82,8 @@ class ADBackend(Enum):
     BD_WINBIND = 1
 
 
-# pylint: disable=useless-object-inheritance, too-few-public-methods
-class ADConfig(object):
+class ADConfig():
     """Base class for AD configuration"""
-    #pylint: disable=too-many-arguments
 
     def __init__(self, path, session, args, ad_enabled=True, load_existing=True, file_mode=0o644):
         self._file_path = path
@@ -257,6 +256,7 @@ class UsersList(DynamicPam):
 
     def _add_upn(self, subject_rec):
         sep = "@"
+        upn = ""
         try:
             upn = subject_rec["other_config"]["subject-upn"]
             user, domain = upn.split(sep)

--- a/scripts/plugins/test_extauth_hook_AD.py
+++ b/scripts/plugins/test_extauth_hook_AD.py
@@ -6,12 +6,19 @@ import sys
 import os
 from unittest import TestCase
 from mock import MagicMock, patch
+
+import pytest
+
 # mock modules to avoid dependencies
 sys.modules["XenAPIPlugin"] = MagicMock()
 sys.modules["XenAPI"] = MagicMock()
 # pylint: disable=wrong-import-position
 # Import must after mock modules
 from extauth_hook_ad import StaticSSHPam, NssConfig, SshdConfig, UsersList, GroupsList
+
+
+if sys.version_info < (3, ):  # pragma: no cover
+    pytest.skip(allow_module_level=True)
 
 
 def line_exists_in_config(lines, line):


### PR DESCRIPTION
Link to open this PR for https://github.com/xapi-project/xen-api/compare/feature/py3:

https://github.com/xapi-project/xen-api/compare/feature/py3...xenserver-next:xen-api:extauth-hook-ad-fix-checker-warnings?expand=1

PR description:

[PATCH 1/2] Stop testing scripts/plugins/extauth-hook-AD.py with Python2.7

Preparations for cleaning up the checker warnings in extauth-hook-AD.py:

1. The shebang of extauth-hook-AD.py has already been changed to Python3:
   Thus, stop testing it with Python3.

2. This drops the Python2 code coverage to 28% (below 50%).
   We need to allow further drops in coverage: Set the limit to 0.

---

[PATCH 2/2] extauth-hook-AD.py: Fix `pytype` warnings, clean-up `pylint`
 suppressions

1. `pytype` warnings need to be fixed before it can be moved to Python3.
   - `pytype` reports the uses `@abc.abstractmethod` as stray, disable.
   - Initialise `upn`: checkers (`pytype`, `pyright`) can't see that
     it is already handled OK.

2. Clean-up obsolete inheriting from `object`: In Python3, all classes
   already always inherit from `object`.